### PR TITLE
feat: auto position_log sync on daily refresh

### DIFF
--- a/app/admin/positions/page.tsx
+++ b/app/admin/positions/page.tsx
@@ -14,10 +14,23 @@ type UpdateResult = {
   error?: string;
 };
 
+type SyncLogResult = {
+  ok: boolean;
+  season?: number;
+  playersProcessed?: number;
+  posLogUpserted?: number;
+  gamesForEligible?: number;
+  error?: string;
+};
+
 export default function PositionsPage() {
   const [busy, setBusy] = useState(false);
   const [result, setResult] = useState<UpdateResult | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  const [syncBusy, setSyncBusy] = useState(false);
+  const [syncResult, setSyncResult] = useState<SyncLogResult | null>(null);
+  const [syncError, setSyncError] = useState<string | null>(null);
 
   const run = async () => {
     setBusy(true);
@@ -32,6 +45,22 @@ export default function PositionsPage() {
       setError(e instanceof Error ? e.message : 'Position update failed');
     } finally {
       setBusy(false);
+    }
+  };
+
+  const syncLog = async () => {
+    setSyncBusy(true);
+    setSyncResult(null);
+    setSyncError(null);
+    try {
+      const res = await fetch('/api/players/sync-position-log', { method: 'POST' });
+      const data: SyncLogResult = await res.json().catch(() => ({}));
+      if (!res.ok || !data.ok) throw new Error(data.error || 'Position log sync failed');
+      setSyncResult(data);
+    } catch (e) {
+      setSyncError(e instanceof Error ? e.message : 'Position log sync failed');
+    } finally {
+      setSyncBusy(false);
     }
   };
 
@@ -106,6 +135,44 @@ export default function PositionsPage() {
                 </div>
               </>
             )}
+          </div>
+        )}
+      </div>
+
+      <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6 space-y-5">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-900">Sync Eligibility (position_log only)</h2>
+          <p className="text-gray-500 text-sm mt-1">
+            Updates <code>position_log</code> eligibility from current-season statlines and rebuilds
+            the player cache. Does <strong>not</strong> touch CommishPos. This is the same step
+            that runs automatically at the end of every daily stat refresh.
+          </p>
+        </div>
+
+        {syncError && (
+          <div className="rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-800">
+            {syncError}
+          </div>
+        )}
+
+        <button
+          onClick={syncLog}
+          disabled={syncBusy}
+          className="rounded-lg bg-blue-600 px-5 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors"
+        >
+          {syncBusy ? 'Syncing eligibility…' : 'Sync Position Log'}
+        </button>
+
+        {syncResult?.ok && (
+          <div className="rounded-lg bg-blue-50 border border-blue-200 px-4 py-3 text-sm text-blue-900 space-y-1">
+            <div className="font-medium">✓ position_log synced for {syncResult.season} season</div>
+            <div>
+              {syncResult.playersProcessed} players processed &bull;{' '}
+              {syncResult.posLogUpserted} position_log records updated
+            </div>
+            <div className="text-blue-700">
+              Eligibility threshold: ≥&nbsp;{syncResult.gamesForEligible} games at a position
+            </div>
           </div>
         )}
       </div>

--- a/app/api/jobs/daily-stat-refresh/route.ts
+++ b/app/api/jobs/daily-stat-refresh/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { connectToDatabase } from '@/app/lib/mongodb';
 import { runDailyStatRefresh } from '@/app/lib/stat-refresh-service';
 import { getAdminAuthState } from '@/app/lib/admin-auth';
+import { syncPositionLog } from '@/app/api/players/sync-position-log/route';
 
 async function isAuthorized(request: NextRequest): Promise<boolean> {
   const { isAdmin } = await getAdminAuthState();
@@ -94,6 +95,8 @@ async function handleRefresh(request: NextRequest) {
         });
       }
 
+      const posLogSummary = await syncPositionLog(db).catch((e) => ({ error: String(e) }));
+
       return NextResponse.json(
         {
           ok: true,
@@ -114,6 +117,7 @@ async function handleRefresh(request: NextRequest) {
               errors: totalRecalcErrors,
             },
           }),
+          posLogSummary,
           daysProcessed: results.length,
           byDay: results,
         },
@@ -124,6 +128,7 @@ async function handleRefresh(request: NextRequest) {
     // Single date mode (original behavior)
     const targetDate = parseTargetDate(dateParam);
     const summary = await runDailyStatRefresh(db, targetDate, { recalculate });
+    const posLogSummary = await syncPositionLog(db).catch((e) => ({ error: String(e) }));
 
     return NextResponse.json(
       {
@@ -131,6 +136,7 @@ async function handleRefresh(request: NextRequest) {
         targetDate: targetDate.toISOString().substring(0, 10),
         recalculate,
         ...summary,
+        posLogSummary,
       },
       { status: 200 }
     );

--- a/app/api/players/refresh-cache/route.ts
+++ b/app/api/players/refresh-cache/route.ts
@@ -16,10 +16,7 @@
 import { NextResponse } from 'next/server';
 import { connectToDatabase } from '@/app/lib/mongodb';
 import { getAdminAuthState } from '@/app/lib/admin-auth';
-import { calculateAblScore } from '@/app/lib/roster-utils';
-
-// Stats written before Opening Day are from the prior season
-const SEASON_START = new Date('2026-03-26T00:00:00Z');
+import { rebuildPlayersCache } from '@/app/lib/roster-utils';
 
 export async function POST() {
   try {
@@ -31,47 +28,9 @@ export async function POST() {
     const db = await connectToDatabase();
     const t0 = Date.now();
 
-    // Run the full players_view pipeline and write results atomically to players_cache.
-    // $out replaces the target collection in a single atomic operation — reads against
-    // players_cache continue to see the old data until the write completes.
-    await db.collection('players_view').aggregate([
-      { $out: 'players_cache' },
-    ]).toArray();
-
-    // Index mlbID for the projection join in /api/players
-    await db.collection('players_cache').createIndex({ mlbID: 1 }, { background: true });
-
-    // Post-process: pre-compute abl score and strip stale stats so every
-    // subsequent read is a zero-cost find().
-    const allDocs = await db.collection('players_cache').find({}, {
-      projection: { _id: 1, stats: 1, lastStatUpdate: 1 },
-    }).toArray();
-
-    const bulkOps: any[] = [];
-    for (const doc of allDocs) {
-      const lastUpdate = doc.lastStatUpdate ? new Date(doc.lastStatUpdate) : null;
-      const statsAreStale = !lastUpdate || lastUpdate < SEASON_START;
-      const stats = statsAreStale ? undefined : doc.stats;
-      const abl = calculateAblScore(stats);
-
-      const setFields: any = { abl };
-      const unsetFields: any = {};
-      if (statsAreStale && doc.stats) {
-        unsetFields.stats = '';
-      }
-
-      const update: any = { $set: setFields };
-      if (Object.keys(unsetFields).length > 0) update.$unset = unsetFields;
-
-      bulkOps.push({ updateOne: { filter: { _id: doc._id }, update } });
-    }
-
-    if (bulkOps.length > 0) {
-      await db.collection('players_cache').bulkWrite(bulkOps, { ordered: false });
-    }
+    const count = await rebuildPlayersCache(db);
 
     const elapsed = Date.now() - t0;
-    const count = await db.collection('players_cache').countDocuments();
 
     console.log(`[refresh-cache] players_cache rebuilt: ${count} docs in ${elapsed}ms (${bulkOps.length} post-processed)`);
     return NextResponse.json({ ok: true, players: count, ms: elapsed });

--- a/app/api/players/refresh-cache/route.ts
+++ b/app/api/players/refresh-cache/route.ts
@@ -32,7 +32,7 @@ export async function POST() {
 
     const elapsed = Date.now() - t0;
 
-    console.log(`[refresh-cache] players_cache rebuilt: ${count} docs in ${elapsed}ms (${bulkOps.length} post-processed)`);
+    console.log(`[refresh-cache] players_cache rebuilt: ${count} docs in ${elapsed}ms`);
     return NextResponse.json({ ok: true, players: count, ms: elapsed });
   } catch (error) {
     console.error('Error rebuilding player cache:', error);

--- a/app/api/players/sync-position-log/route.ts
+++ b/app/api/players/sync-position-log/route.ts
@@ -1,0 +1,144 @@
+/**
+ * POST /api/players/sync-position-log
+ *
+ * Updates position_log eligibility from current-season statlines WITHOUT
+ * touching the `positions` collection (CommishPos). CommishPos is a one-time
+ * commish-set value; this route is safe to run on every daily stat refresh.
+ *
+ * Writes to position_log:
+ *   { mlbId, season, maxPosition, eligiblePositions, positionsLog }
+ *
+ * Then triggers players_cache rebuild so updated eligibility is live immediately.
+ *
+ * Can be called by the daily-stat-refresh job (no auth cookie needed when using
+ * the CRON_SECRET header) or manually from the admin UI.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { Db } from 'mongodb';
+import { connectToDatabase } from '@/app/lib/mongodb';
+import { getAdminAuthState } from '@/app/lib/admin-auth';
+import { rebuildPlayersCache } from '@/app/lib/roster-utils';
+
+const SEASON_YEAR = 2026;
+const GAMES_FOR_ELIGIBLE = 10;
+const EXCLUDED = new Set(['PH', 'PR', 'P']);
+const OF_POSITIONS = new Set(['RF', 'CF', 'LF']);
+
+function normalizePos(pos: string): string {
+  return OF_POSITIONS.has(pos) ? 'OF' : pos;
+}
+
+export async function syncPositionLog(db: Db): Promise<{
+  playersProcessed: number;
+  posLogUpserted: number;
+}> {
+  const seasonPrefix = `${SEASON_YEAR}-`;
+  const statDocs = await db
+    .collection('statlines')
+    .find({ _id: { $regex: `^${seasonPrefix}` } as any }, { projection: { p: 1 } })
+    .toArray();
+
+  if (statDocs.length === 0) {
+    return { playersProcessed: 0, posLogUpserted: 0 };
+  }
+
+  // Aggregate per-player position counts: mlbId → { pos → games }
+  const playerPosCounts = new Map<string, Map<string, number>>();
+
+  for (const doc of statDocs) {
+    const entries: Record<string, { pos?: string[] }> = (doc as any).p ?? {};
+    for (const [key, val] of Object.entries(entries)) {
+      const mlbId = key.split('_')[0];
+      const rawPositions: string[] = val.pos ?? [];
+
+      let counts = playerPosCounts.get(mlbId);
+      if (!counts) {
+        counts = new Map();
+        playerPosCounts.set(mlbId, counts);
+      }
+
+      // Normalize and deduplicate within game (RF+CF = 1 OF credit)
+      const normalized = [...new Set(rawPositions.map(normalizePos))];
+      for (const pos of normalized) {
+        if (!EXCLUDED.has(pos)) {
+          counts.set(pos, (counts.get(pos) ?? 0) + 1);
+        }
+      }
+    }
+  }
+
+  // Build bulk write ops for position_log only
+  const posLogOps: any[] = [];
+
+  for (const [mlbId, counts] of playerPosCounts) {
+    const sorted = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+    const maxPos = sorted[0]?.[0] ?? 'DH';
+    const eligiblePositions = sorted
+      .filter(([, ct]) => ct >= GAMES_FOR_ELIGIBLE)
+      .map(([pos]) => pos);
+    const positionsLog = sorted.map(([pos, ct]) => ({ pos, ct }));
+
+    posLogOps.push({
+      updateOne: {
+        filter: { mlbId, season: SEASON_YEAR },
+        update: {
+          $set: {
+            mlbId,
+            season: SEASON_YEAR,
+            maxPosition: maxPos,
+            eligiblePositions,
+            positionsLog,
+          },
+        },
+        upsert: true,
+      },
+    });
+  }
+
+  const BATCH = 500;
+  let posLogUpserted = 0;
+  for (let i = 0; i < posLogOps.length; i += BATCH) {
+    const r = await db.collection('position_log').bulkWrite(posLogOps.slice(i, i + BATCH), { ordered: false });
+    posLogUpserted += r.upsertedCount + r.modifiedCount;
+  }
+
+  // Rebuild players_cache so updated eligibility is immediately live
+  await rebuildPlayersCache(db);
+
+  return { playersProcessed: playerPosCounts.size, posLogUpserted };
+}
+
+function isAuthorized(request: NextRequest): boolean {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) return false;
+  const authHeader = request.headers.get('authorization') || '';
+  const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7).trim() : '';
+  const headerSecret = request.headers.get('x-cron-secret') || '';
+  return token === secret || headerSecret === secret;
+}
+
+export async function POST(request: NextRequest) {
+  const { isAdmin } = await getAdminAuthState();
+  if (!isAdmin && !isAuthorized(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const db = await connectToDatabase();
+    const { playersProcessed, posLogUpserted } = await syncPositionLog(db);
+    return NextResponse.json({
+      ok: true,
+      season: SEASON_YEAR,
+      gamesForEligible: GAMES_FOR_ELIGIBLE,
+      playersProcessed,
+      posLogUpserted,
+    });
+  } catch (error) {
+    console.error('sync-position-log failed:', error);
+    return NextResponse.json(
+      { ok: false, error: error instanceof Error ? error.message : 'sync-position-log failed' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/lib/roster-utils.ts
+++ b/app/lib/roster-utils.ts
@@ -56,6 +56,46 @@ export function calculateAblPoints(stats: any): number {
 }
 
 /**
+ * Rebuilds players_cache from players_view, then post-processes:
+ *   - Computes `abl` score for each player
+ *   - Strips stale stats (lastStatUpdate before SEASON_START)
+ *   - Creates mlbID index
+ * Returns count of docs processed.
+ */
+const SEASON_START = new Date('2026-03-26T00:00:00Z');
+
+export async function rebuildPlayersCache(db: Db): Promise<number> {
+  await db.collection('players_view').aggregate([{ $out: 'players_cache' }]).toArray();
+  await db.collection('players_cache').createIndex({ mlbID: 1 }, { background: true });
+
+  const allDocs = await db.collection('players_cache').find({}, {
+    projection: { _id: 1, stats: 1, lastStatUpdate: 1 },
+  }).toArray();
+
+  const bulkOps: any[] = [];
+  for (const doc of allDocs) {
+    const lastUpdate = doc.lastStatUpdate ? new Date(doc.lastStatUpdate) : null;
+    const statsAreStale = !lastUpdate || lastUpdate < SEASON_START;
+    const stats = statsAreStale ? undefined : doc.stats;
+    const abl = calculateAblScore(stats);
+
+    const setFields: any = { abl };
+    const unsetFields: any = {};
+    if (statsAreStale && doc.stats) unsetFields.stats = '';
+
+    const update: any = { $set: setFields };
+    if (Object.keys(unsetFields).length > 0) update.$unset = unsetFields;
+    bulkOps.push({ updateOne: { filter: { _id: doc._id }, update } });
+  }
+
+  if (bulkOps.length > 0) {
+    await db.collection('players_cache').bulkWrite(bulkOps, { ordered: false });
+  }
+
+  return allDocs.length;
+}
+
+/**
  * Convert a date to noon Central Time, returned as UTC
  * Handles DST properly
  */


### PR DESCRIPTION
- New /api/players/sync-position-log route: updates position_log eligibility from statlines without touching CommishPos, then rebuilds players_cache
- Wired into daily-stat-refresh (runs automatically after every stat pull)
- Admin button on /admin/positions page for manual on-demand trigger
- Extracted rebuildPlayersCache() to roster-utils.ts (shared by refresh-cache and sync-position-log)  fixes abl pre-compute and stale stat stripping