### PR TITLE
feat: position log tooltip on FA and draft player rows

### DIFF
--- a/app/[league]/[season]/draft/page.tsx
+++ b/app/[league]/[season]/draft/page.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/app/lib/draft-utils';
 import { useLeagueSeason } from '@/app/lib/league-season-context';
 import type { ProjectionStats } from '@/app/lib/projection-utils';
+import { PosLogPopover } from '@/app/ui/pos-log-popover';
 
 type PlayerForDraft = DraftPlayer & {
   abl: number;
@@ -858,7 +859,10 @@ export default function DraftPage() {
                   >
                     <div>
                       <div className="font-medium text-gray-900 leading-tight">{player.name}</div>
-                      <div className="text-xs text-gray-500">{player.team || 'FA'} – {player.eligible.join(', ')}</div>
+                      <div className="text-xs text-gray-500 flex items-center flex-wrap gap-x-0.5">
+                        <span>{player.team || 'FA'} – {player.eligible.join(', ')}</span>
+                        <PosLogPopover mlbId={player.mlbID} />
+                      </div>
                       {player.status && <div className="text-xs text-gray-400">{player.status}</div>}
                     </div>
                     <div className={`text-center text-xs ${STAT_VIS[0]} ${statC(ds.g)}`}>{fmt(ds.g)}</div>

--- a/app/[league]/[season]/teams/[id]/free-agents/page.tsx
+++ b/app/[league]/[season]/teams/[id]/free-agents/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { useLeagueSeason } from '@/app/lib/league-season-context';
 import type { ProjectionStats } from '@/app/lib/projection-utils';
+import { PosLogPopover } from '@/app/ui/pos-log-popover';
 
 interface Player {
   _id: string;
@@ -12,6 +13,7 @@ interface Player {
   team: string;
   eligible?: string[];
   position?: string;
+  mlbID?: string | number;
   status?: string;
   abl?: number;
   ablProjected?: number | null;
@@ -527,7 +529,10 @@ export default function FreeAgentsPage() {
               >
                 <div>
                   <div className="font-medium text-gray-900 leading-tight">{player.name}</div>
-                  <div className="text-xs text-gray-500">{player.team || 'FA'} – {player.eligible?.join(', ') || '—'}</div>
+                  <div className="text-xs text-gray-500 flex items-center flex-wrap gap-x-0.5">
+                    <span>{player.team || 'FA'} – {player.eligible?.join(', ') || '—'}</span>
+                    <PosLogPopover mlbId={player.mlbID} />
+                  </div>
                   {player.status && <div className="text-xs text-gray-400">{player.status}</div>}
                 </div>
                 <div className={`text-center text-xs ${STAT_VIS[0]} ${statC(ds.g)}`}>{fmt(ds.g)}</div>

--- a/app/api/players/[id]/position-log/route.ts
+++ b/app/api/players/[id]/position-log/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { connectToDatabase } from '@/app/lib/mongodb';
+
+const SEASON_YEAR = 2026;
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id: mlbId } = await params;
+    const db = await connectToDatabase();
+    const doc = await db.collection('position_log').findOne(
+      { mlbId: String(mlbId), season: SEASON_YEAR },
+      { projection: { positionsLog: 1, eligiblePositions: 1, _id: 0 } },
+    );
+    if (!doc) {
+      return NextResponse.json({ positionsLog: [], eligiblePositions: [] });
+    }
+    return NextResponse.json({
+      positionsLog: doc.positionsLog ?? [],
+      eligiblePositions: doc.eligiblePositions ?? [],
+    });
+  } catch {
+    return NextResponse.json({ error: 'Failed to fetch position log' }, { status: 500 });
+  }
+}

--- a/app/lib/draft-utils.ts
+++ b/app/lib/draft-utils.ts
@@ -22,6 +22,7 @@ export type DraftPlayer = {
   position?: string;
   eligible?: string[];
   mlbPosition?: string;
+  mlbID?: string | number;
   status?: string;
   stats?: any;
 };

--- a/app/ui/pos-log-popover.tsx
+++ b/app/ui/pos-log-popover.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+type PosEntry = { pos: string; ct: number };
+type PosLogData = { positionsLog: PosEntry[]; eligiblePositions: string[] };
+
+const THRESHOLD = 10;
+// Module-level cache — persists for the lifetime of the page, cleared on full navigation
+const posLogCache = new Map<string, PosLogData | null>();
+
+export function PosLogPopover({ mlbId }: { mlbId?: string | number }) {
+  const [open, setOpen] = useState(false);
+  const [data, setData] = useState<PosLogData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const ref = useRef<HTMLSpanElement>(null);
+
+  // Close popover on outside click
+  useEffect(() => {
+    if (!open) return;
+    function handleClickOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [open]);
+
+  async function toggle(e: React.MouseEvent) {
+    e.stopPropagation();
+    if (!mlbId) return;
+    const key = String(mlbId);
+    if (open) {
+      setOpen(false);
+      return;
+    }
+    setOpen(true);
+    if (posLogCache.has(key)) {
+      setData(posLogCache.get(key) ?? null);
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/players/${key}/position-log`);
+      if (res.ok) {
+        const json: PosLogData = await res.json();
+        posLogCache.set(key, json);
+        setData(json);
+      } else {
+        posLogCache.set(key, null);
+        setData(null);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (!mlbId) return null;
+
+  return (
+    <span ref={ref} className="relative inline-flex items-center">
+      <button
+        type="button"
+        onClick={toggle}
+        className="ml-1 inline-flex items-center text-gray-400 hover:text-blue-500 leading-none focus:outline-none"
+        title="View 2026 position log"
+        aria-label="View position log"
+        aria-expanded={open}
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-3 h-3">
+          <path fillRule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0ZM8.94 6.94a.75.75 0 1 1-1.061-1.061 3 3 0 1 1 2.871 5.026v.345a.75.75 0 0 1-1.5 0v-.5c0-.72.57-1.172 1.081-1.287A1.5 1.5 0 1 0 8.94 6.94ZM10 15a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clipRule="evenodd" />
+        </svg>
+      </button>
+      {open && (
+        <div className="absolute left-0 top-5 z-50 w-44 rounded-lg border border-gray-200 bg-white p-3 shadow-lg">
+          <div className="text-xs font-semibold text-gray-700 mb-2">2026 Position Log</div>
+          {loading ? (
+            <div className="text-xs text-gray-400">Loading…</div>
+          ) : !data || data.positionsLog.length === 0 ? (
+            <div className="text-xs text-gray-400">No data yet</div>
+          ) : (
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="text-gray-400">
+                  <th className="text-left font-normal pb-1">Pos</th>
+                  <th className="text-right font-normal pb-1 pr-2">G</th>
+                  <th />
+                </tr>
+              </thead>
+              <tbody>
+                {data.positionsLog.map(({ pos, ct }) => {
+                  const eligible = ct >= THRESHOLD;
+                  const needed = THRESHOLD - ct;
+                  return (
+                    <tr key={pos}>
+                      <td className="pr-2 font-medium text-gray-700">{pos}</td>
+                      <td className="pr-2 text-right tabular-nums text-gray-600">{ct}</td>
+                      <td className="whitespace-nowrap">
+                        {eligible
+                          ? <span className="text-green-600 font-semibold">✓</span>
+                          : <span className="text-gray-400">+{needed}</span>}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          )}
+          <div className="mt-2 border-t border-gray-100 pt-1 text-xs text-gray-400">≥{THRESHOLD}g = eligible</div>
+        </div>
+      )}
+    </span>
+  );
+}


### PR DESCRIPTION
- Add GET /api/players/[id]/position-log  returns positionsLog and eligiblePositions from position_log collection for 2026 season
- Add PosLogPopover component (app/ui/pos-log-popover.tsx)  lazy-fetches on first open, caches results, closes on outside click
- Add mlbID field to DraftPlayer type in draft-utils.ts
- Add mlbID field to Player interface on FA page
- Wire PosLogPopover into player rows on FA page and draft available players list