### PR TITLE
feat: show site display names for team owners on draft board

### DIFF
--- a/app/[league]/[season]/draft/page.tsx
+++ b/app/[league]/[season]/draft/page.tsx
@@ -516,7 +516,7 @@ export default function DraftPage() {
   };
 
   const handleUndo = async () => {
-    if (!activeDraft) return;
+    if (!activeDraft || !isAdmin) return;
     try {
       setIsWorking(true);
       setError(null);
@@ -621,6 +621,7 @@ export default function DraftPage() {
               {adminPickMode ? '🔓 Admin Pick Mode ON' : '🔒 Admin Pick Mode'}
             </button>
           )}
+          {isAdmin && (
           <button
             type="button"
             onClick={handleUndo}
@@ -629,6 +630,7 @@ export default function DraftPage() {
           >
             Undo Last Pick
           </button>
+          )}
           {isAdmin && activeDraft && (
             <button
               type="button"

--- a/app/api/teams/route.ts
+++ b/app/api/teams/route.ts
@@ -2,6 +2,23 @@ import { NextRequest, NextResponse } from 'next/server';
 import { connectToDatabase } from '@/app/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import { resolveLeagueContext } from '@/app/lib/league-context';
+import { getDisplayNameMap, sanitizeDisplayName } from '@/app/lib/display-name';
+
+function populateOwnerNames(teams: any[], nameMap: Map<string, string>) {
+  for (const team of teams) {
+    if (!Array.isArray(team.owners)) continue;
+    for (const owner of team.owners) {
+      if (!owner.userId) continue;
+      const display = nameMap.get(owner.userId);
+      if (display) {
+        owner.name = display;
+      } else if (!owner.name || owner.name === owner.userId) {
+        // Fall back to a sanitized version of whatever name Auth0 gave us
+        owner.name = sanitizeDisplayName(owner.name, owner.userId);
+      }
+    }
+  }
+}
 
 // GET /api/teams?league=abl&season=2025 - Get teams, optionally scoped to a season
 export async function GET(request: NextRequest) {
@@ -21,11 +38,17 @@ export async function GET(request: NextRequest) {
       const teams = await db.collection('ablteams')
         .find({ _id: { $in: teamIds } })
         .toArray();
+      const userIds = teams.flatMap((t: any) => (t.owners ?? []).map((o: any) => o.userId).filter(Boolean));
+      const nameMap = await getDisplayNameMap(db, userIds);
+      populateOwnerNames(teams, nameMap);
       return NextResponse.json(teams);
     }
 
     // No filter — return all teams (admin / legacy use)
     const teams = await db.collection('ablteams').find({}).toArray();
+    const userIds = teams.flatMap((t: any) => (t.owners ?? []).map((o: any) => o.userId).filter(Boolean));
+    const nameMap = await getDisplayNameMap(db, userIds);
+    populateOwnerNames(teams, nameMap);
     return NextResponse.json(teams);
   } catch (error) {
     console.error('Error fetching teams:', error);


### PR DESCRIPTION
- /api/teams now resolves owner.userId against user_profiles collection and populates owner.name with the stored display name (falls back to sanitizeDisplayName if no profile exists yet)
- Draft Undo Last Pick button is now admin-only (matches Finalize guard)