### PR TITLE
fix: correct getNextRosterGameDate pre-lock effectiveDate bug

### DIFF
--- a/app/api/games/recalculate/route.ts
+++ b/app/api/games/recalculate/route.ts
@@ -5,6 +5,20 @@ import { calculateAndStoreLiveGameResult } from '@/app/lib/game-calculation-serv
 import { ensureRostersLockedForGames } from '@/app/lib/stat-refresh-service';
 import { getAdminAuthState } from '@/app/lib/admin-auth';
 
+async function isAuthorized(request: NextRequest): Promise<boolean> {
+  const { isAdmin } = await getAdminAuthState();
+  if (isAdmin) return true;
+
+  const secret = process.env.CRON_SECRET;
+  if (!secret) return false;
+
+  const authHeader = request.headers.get('authorization') || '';
+  const token = authHeader.startsWith('Bearer ') ? authHeader.substring(7).trim() : '';
+  const headerSecret = request.headers.get('x-cron-secret') || '';
+
+  return token === secret || headerSecret === secret;
+}
+
 type LineupPlayer = {
   player?: { _id?: any; mlbID?: any; mlbId?: any; name?: string };
   _id?: any;
@@ -384,8 +398,7 @@ function compareGameScores(game: any, calculatedResult: any) {
 
 export async function POST(request: NextRequest) {
   try {
-    const { isAdmin } = await getAdminAuthState();
-    if (!isAdmin) {
+    if (!(await isAuthorized(request))) {
       return NextResponse.json({ error: 'Admin access required' }, { status: 403 });
     }
 

--- a/app/lib/roster-utils.ts
+++ b/app/lib/roster-utils.ts
@@ -1,4 +1,5 @@
 import { Db } from 'mongodb';
+import { deriveAblDate } from '@/app/lib/abl-date';
 
 /**
  * Calculate ABL (ABL Fantasy) score from batting stats
@@ -198,10 +199,36 @@ export async function getFirstMlbGameTimeForDate(db: Db, officialDate: string): 
 /**
  * Returns the YYYY-MM-DD date string for the next upcoming ABL game day.
  * This is the value stored in lineups.effectiveDate.
+ *
+ * Logic:
+ *   - If today's roster is NOT yet locked (first MLB game hasn't started), return
+ *     today's ABL date. The effectiveDate should be TODAY so that any roster
+ *     changes made before lock are applied to today's games.
+ *   - If today's roster IS locked, find the next ABL game date after today and
+ *     return that. Edits made after lock apply to the next game day.
+ *
+ * This replaces the previous approach of querying ABL games with
+ * `gameDate >= now`, which broke because ABL game records store gameDate as
+ * midnight UTC — by evening that timestamp has already passed and the query
+ * incorrectly jumped to the next day, causing the lineup to be saved with the
+ * wrong effectiveDate and skipped during scoring.
  */
 export async function getNextRosterGameDate(db: Db): Promise<string> {
+  const todayAblDate = deriveAblDate(new Date());
+
+  // Check whether today's roster window has closed (first MLB game started)
+  const lockTime = await getFirstMlbGameTimeForDate(db, todayAblDate);
+  if (Date.now() < lockTime.getTime()) {
+    // Pre-lock: changes are for today's games
+    return todayAblDate;
+  }
+
+  // Post-lock: find the next ABL game date strictly after today
+  const [y, m, d] = todayAblDate.split('-').map(Number);
+  const tomorrowStart = new Date(Date.UTC(y, m - 1, d + 1, 0, 0, 0, 0));
+
   const nextGames = await db.collection('games')
-    .find({ gameDate: { $gte: new Date() }, gameType: 'R' })
+    .find({ gameDate: { $gte: tomorrowStart }, gameType: 'R' })
     .sort({ gameDate: 1 })
     .limit(1)
     .toArray();

--- a/scripts/audit-score-changes.mjs
+++ b/scripts/audit-score-changes.mjs
@@ -1,0 +1,330 @@
+/**
+ * scripts/audit-score-changes.mjs
+ *
+ * Compares game results between the prod DB (old scores, before fix) and the
+ * local dev DB (new scores, after effectiveDate fix + recalculation) for all
+ * ABL game dates in the affected range (April 16 – May 26, 2026).
+ *
+ * Prerequisites:
+ *   1. Fix applied to local DB:  DRY_RUN=false node scripts/fix-effectivedate-bug.mjs
+ *   2. Local scores recalculated: node scripts/recalculate-affected-dates.mjs
+ *   3. PROD_MONGODB_URI set (in env or .env.local):
+ *        PROD_MONGODB_URI=mongodb+srv://<user>:<pass>@<host>/<prod-db>
+ *
+ * Usage:
+ *   node scripts/audit-score-changes.mjs
+ *   PROD_MONGODB_URI="..." node scripts/audit-score-changes.mjs
+ *
+ * Output:
+ *   - Console: human-readable report of all changed games
+ *   - File:    scripts/audit-output/score-audit-<timestamp>.txt
+ */
+
+import { readFileSync, mkdirSync, writeFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { MongoClient } from 'mongodb';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// --- Parse .env.local ---
+const envPath = resolve(__dirname, '..', '.env.local');
+const envVars = Object.fromEntries(
+  readFileSync(envPath, 'utf8').split('\n')
+    .filter(l => l.includes('=') && !l.startsWith('#'))
+    .map(l => {
+      const idx = l.indexOf('=');
+      return [l.slice(0, idx).trim(), l.slice(idx + 1).trim()];
+    })
+);
+
+function getEnv(key) {
+  return process.env[key] || envVars[key] || '';
+}
+
+const LOCAL_URI = getEnv('MONGODB_URI');
+const PROD_URI  = getEnv('PROD_MONGODB_URI');
+
+if (!LOCAL_URI) {
+  console.error('MONGODB_URI not found in .env.local');
+  process.exit(1);
+}
+if (!PROD_URI) {
+  console.error(
+    'PROD_MONGODB_URI not set.\n' +
+    'Add it to .env.local or pass it as:\n' +
+    '  PROD_MONGODB_URI="mongodb+srv://..." node scripts/audit-score-changes.mjs'
+  );
+  process.exit(1);
+}
+
+function extractDbName(uri) {
+  const match = uri.match(/\/([^/?]+)(\?|$)/);
+  return match?.[1] ?? null;
+}
+
+const LOCAL_DB_NAME = extractDbName(LOCAL_URI);
+const PROD_DB_NAME  = extractDbName(PROD_URI);
+
+// Date range that covers all 58 affected lineups
+const DATE_START = new Date('2026-04-16T00:00:00.000Z');
+const DATE_END   = new Date('2026-05-27T00:00:00.000Z'); // exclusive
+
+// -----------------------------------------------------------------------
+
+function fmt(n) {
+  if (n == null) return '    ?   ';
+  return n.toFixed(4).padStart(8);
+}
+
+function winnerLabel(teamId, teamMap) {
+  if (!teamId) return '???';
+  return teamMap.get(teamId.toString()) || teamId.toString().slice(-6);
+}
+
+function getScore(result, location) {
+  if (!result?.scores) return null;
+  const s = result.scores.find(s => s.location === location);
+  return s?.final ?? s?.regulation ?? null;
+}
+
+function getWinnerId(result) {
+  return result?.winner?.toString?.() ?? null;
+}
+
+// -----------------------------------------------------------------------
+
+console.log('ABL effectiveDate bug — Score Audit\n');
+console.log(`  Local DB : ${LOCAL_DB_NAME}`);
+console.log(`  Prod  DB : ${PROD_DB_NAME}`);
+console.log(`  Date range: ${DATE_START.toISOString().slice(0,10)} → ${new Date(DATE_END - 1).toISOString().slice(0,10)}\n`);
+
+const localClient = new MongoClient(LOCAL_URI);
+const prodClient  = new MongoClient(PROD_URI);
+
+await localClient.connect();
+await prodClient.connect();
+
+const localDb = localClient.db(LOCAL_DB_NAME);
+const prodDb  = prodClient.db(PROD_DB_NAME);
+
+try {
+  // --- Load team nicknames from both DBs (prefer local, fall back to prod) ---
+  const [localTeams, prodTeams] = await Promise.all([
+    localDb.collection('teams').find({}, { projection: { _id: 1, nickname: 1, name: 1 } }).toArray(),
+    prodDb.collection('teams').find({},  { projection: { _id: 1, nickname: 1, name: 1 } }).toArray(),
+  ]);
+  const teamMap = new Map();
+  for (const t of [...prodTeams, ...localTeams]) {
+    teamMap.set(t._id.toString(), t.nickname || t.name || t._id.toString());
+  }
+
+  // --- Load all games in the affected range from both DBs ---
+  const gameFilter = {
+    gameDate: { $gte: DATE_START, $lt: DATE_END },
+    gameType: 'R',
+  };
+
+  const [localGames, prodGames] = await Promise.all([
+    localDb.collection('games').find(gameFilter).sort({ gameDate: 1 }).toArray(),
+    prodDb.collection('games').find(gameFilter).sort({ gameDate: 1 }).toArray(),
+  ]);
+
+  console.log(`  Local games found: ${localGames.length}`);
+  console.log(`  Prod  games found: ${prodGames.length}\n`);
+
+  // Index prod games by _id for quick lookup
+  const prodById = new Map(prodGames.map(g => [g._id.toString(), g]));
+
+  // -----------------------------------------------------------------------
+  // Compare each local game against its prod counterpart
+  // -----------------------------------------------------------------------
+
+  const lines = [];
+  const outcomeChanges = [];
+  const scoreChanges = [];
+
+  // Group games by ABL date
+  function ablDate(gameDate) {
+    const d = new Date(gameDate);
+    const shifted = new Date(d.getTime() - 8 * 60 * 60 * 1000);
+    return shifted.toISOString().slice(0, 10);
+  }
+
+  const gamesByDate = new Map();
+  for (const g of localGames) {
+    const d = ablDate(g.gameDate);
+    if (!gamesByDate.has(d)) gamesByDate.set(d, []);
+    gamesByDate.get(d).push(g);
+  }
+
+  let totalGames = 0;
+  let totalScoreChanges = 0;
+  let totalOutcomeChanges = 0;
+  let totalNoProdResult = 0;
+  let totalNoLocalResult = 0;
+
+  for (const [date, games] of [...gamesByDate.entries()].sort()) {
+    const dateLines = [];
+    let dateHasChanges = false;
+
+    for (const localGame of games) {
+      const prodGame = prodById.get(localGame._id.toString());
+      const homeId   = (localGame.homeTeam ?? localGame.homeTeamId)?.toString?.();
+      const awayId   = (localGame.awayTeam ?? localGame.awayTeamId)?.toString?.();
+      const homeName = teamMap.get(homeId) || homeId?.slice(-6) || '???';
+      const awayName = teamMap.get(awayId) || awayId?.slice(-6) || '???';
+
+      totalGames++;
+
+      const prodResult  = prodGame?.result;
+      const localResult = localGame?.result;
+
+      if (!prodResult) {
+        totalNoProdResult++;
+        dateLines.push(`  GAME: ${homeName} (H) vs ${awayName} (A)`);
+        dateLines.push(`    ⚠️  No prod result found — skipping`);
+        dateLines.push('');
+        continue;
+      }
+      if (!localResult) {
+        totalNoLocalResult++;
+        dateLines.push(`  GAME: ${homeName} (H) vs ${awayName} (A)`);
+        dateLines.push(`    ⚠️  No local result — recalculation may not have run yet`);
+        dateLines.push('');
+        continue;
+      }
+
+      const prodHome  = getScore(prodResult,  'H');
+      const prodAway  = getScore(prodResult,  'A');
+      const localHome = getScore(localResult, 'H');
+      const localAway = getScore(localResult, 'A');
+
+      const prodWinnerId  = getWinnerId(prodResult);
+      const localWinnerId = getWinnerId(localResult);
+
+      const homeRunsProd  = prodHome?.abl_runs  ?? null;
+      const awayRunsProd  = prodAway?.abl_runs  ?? null;
+      const homeRunsLocal = localHome?.abl_runs ?? null;
+      const awayRunsLocal = localAway?.abl_runs ?? null;
+
+      // Check for score changes (meaningful = more than floating-point noise)
+      const homeChanged = homeRunsProd != null && homeRunsLocal != null &&
+                          Math.abs(homeRunsProd - homeRunsLocal) > 0.00001;
+      const awayChanged = awayRunsProd != null && awayRunsLocal != null &&
+                          Math.abs(awayRunsProd - awayRunsLocal) > 0.00001;
+
+      const outcomeChanged = prodWinnerId && localWinnerId && prodWinnerId !== localWinnerId;
+
+      if (!homeChanged && !awayChanged) continue; // no difference, skip
+
+      dateHasChanges = true;
+      totalScoreChanges++;
+      if (outcomeChanged) totalOutcomeChanges++;
+
+      const prodWinnerName  = winnerLabel(prodWinnerId,  teamMap);
+      const localWinnerName = winnerLabel(localWinnerId, teamMap);
+
+      const gameLine = `  GAME: ${homeName} (H) vs ${awayName} (A)`;
+      const prodLine = [
+        `    PROD  (old):  ${homeName}${fmt(homeRunsProd)}  |  ${awayName}${fmt(awayRunsProd)}`,
+        `  →  winner: ${prodWinnerName}`,
+      ].join('');
+      const newLine = [
+        `    LOCAL (new):  ${homeName}${fmt(homeRunsLocal)}  |  ${awayName}${fmt(awayRunsLocal)}`,
+        `  →  winner: ${localWinnerName}`,
+        outcomeChanged ? `  ⚠️  OUTCOME CHANGED (${prodWinnerName} → ${localWinnerName})` : '',
+      ].join('');
+
+      // Stat breakdown for home if changed
+      const breakdownLines = [];
+      if (homeChanged) {
+        const ph = prodHome;  const lh = localHome;
+        breakdownLines.push(`    ${homeName}: AB ${ph?.ab??'?'}→${lh?.ab??'?'}  pts ${ph?.abl_points?.toFixed(1)??'?'}→${lh?.abl_points?.toFixed(1)??'?'}  H ${ph?.h??'?'}→${lh?.h??'?'}  HR ${ph?.hr??'?'}→${lh?.hr??'?'}  BB ${ph?.bb??'?'}→${lh?.bb??'?'}`);
+      }
+      if (awayChanged) {
+        const pa = prodAway;  const la = localAway;
+        breakdownLines.push(`    ${awayName}: AB ${pa?.ab??'?'}→${la?.ab??'?'}  pts ${pa?.abl_points?.toFixed(1)??'?'}→${la?.abl_points?.toFixed(1)??'?'}  H ${pa?.h??'?'}→${la?.h??'?'}  HR ${pa?.hr??'?'}→${la?.hr??'?'}  BB ${pa?.bb??'?'}→${la?.bb??'?'}`);
+      }
+
+      dateLines.push(gameLine);
+      dateLines.push(prodLine);
+      dateLines.push(newLine);
+      if (breakdownLines.length) dateLines.push(...breakdownLines);
+      dateLines.push('');
+
+      scoreChanges.push({ date, homeName, awayName, prodWinnerName, localWinnerName, outcomeChanged });
+      if (outcomeChanged) {
+        outcomeChanges.push({ date, homeName, awayName, prodWinnerName, localWinnerName });
+      }
+    }
+
+    if (dateHasChanges) {
+      lines.push(`=== ${date} ===`);
+      lines.push(...dateLines);
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Summary
+  // -----------------------------------------------------------------------
+
+  const summaryLines = [
+    '================================================================',
+    'SUMMARY',
+    '================================================================',
+    `Total games in range   : ${totalGames}`,
+    `Games with score diff  : ${totalScoreChanges}`,
+    `Outcome changes        : ${totalOutcomeChanges}`,
+    `No prod result (skip)  : ${totalNoProdResult}`,
+    `No local result (skip) : ${totalNoLocalResult}`,
+    '',
+  ];
+
+  if (outcomeChanges.length) {
+    summaryLines.push('OUTCOME CHANGES (winner flipped):');
+    for (const oc of outcomeChanges) {
+      summaryLines.push(`  ${oc.date}  ${oc.homeName} (H) vs ${oc.awayName} (A)  :  ${oc.prodWinnerName} → ${oc.localWinnerName}`);
+    }
+    summaryLines.push('');
+  } else {
+    summaryLines.push('No outcome changes — only score magnitudes shifted.');
+    summaryLines.push('');
+  }
+
+  if (scoreChanges.length && !outcomeChanges.length) {
+    summaryLines.push('Games with score changes (no outcome flip):');
+    for (const sc of scoreChanges) {
+      summaryLines.push(`  ${sc.date}  ${sc.homeName} (H) vs ${sc.awayName} (A)  winner unchanged: ${sc.prodWinnerName}`);
+    }
+    summaryLines.push('');
+  }
+
+  const header = [
+    '================================================================',
+    'ABL SCORE AUDIT — effectiveDate bug fix',
+    `Generated : ${new Date().toISOString()}`,
+    `Local DB  : ${LOCAL_DB_NAME}`,
+    `Prod  DB  : ${PROD_DB_NAME}`,
+    `Date range: ${DATE_START.toISOString().slice(0,10)} → ${new Date(DATE_END - 1).toISOString().slice(0,10)}`,
+    '================================================================',
+    '',
+  ];
+
+  const fullReport = [...header, ...summaryLines, ...lines].join('\n');
+
+  // Print to console
+  console.log(fullReport);
+
+  // Write to file
+  const outDir = resolve(__dirname, 'audit-output');
+  mkdirSync(outDir, { recursive: true });
+  const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+  const outPath = resolve(outDir, `score-audit-${ts}.txt`);
+  writeFileSync(outPath, fullReport, 'utf8');
+  console.log(`\nReport saved to: ${outPath}`);
+
+} finally {
+  await localClient.close();
+  await prodClient.close();
+}

--- a/scripts/fix-effectivedate-bug.mjs
+++ b/scripts/fix-effectivedate-bug.mjs
@@ -1,0 +1,212 @@
+/**
+ * fix-effectivedate-bug.mjs
+ *
+ * Finds lineup documents that were saved pre-lock on ABL date D but received
+ * effectiveDate = D+1 (or later) due to the bug where getNextRosterGameDate
+ * used `gameDate >= now` against ABL game records (midnight UTC timestamps),
+ * causing the query to skip today and return tomorrow once the clock passed
+ * midnight UTC — even though the roster lock (first MLB pitch) hadn't fired yet.
+ *
+ * For each affected lineup:
+ *   1. Logs it (team, savedAt, wrong effectiveDate, correct effectiveDate)
+ *   2. In DRY_RUN=false mode:
+ *        a. If a document with the correct effectiveDate already exists for the
+ *           same team, the bugged document's roster overwrites it (since it was
+ *           the most recent save) and the bugged document is deleted.
+ *        b. If no correct-date document exists, the effectiveDate field is
+ *           updated in place.
+ *
+ * Usage:
+ *   node scripts/fix-effectivedate-bug.mjs           # dry run (default)
+ *   DRY_RUN=false node scripts/fix-effectivedate-bug.mjs   # apply fixes
+ */
+
+import { MongoClient } from 'mongodb';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// Capture TARGET_MONGODB_URI before .env.local can overwrite it
+const TARGET_MONGODB_URI_OVERRIDE = process.env.TARGET_MONGODB_URI;
+for (const line of readFileSync(resolve(__dirname, '..', '.env.local'), 'utf8').split(/\r?\n/)) {
+  const m = line.match(/^([^#=\r]+)=(.*)/);
+  if (m) process.env[m[1].trim()] = m[2].trim();
+}
+
+// TARGET_MONGODB_URI (set before script runs) overrides .env.local MONGODB_URI
+const MONGODB_URI = TARGET_MONGODB_URI_OVERRIDE || process.env.MONGODB_URI;
+const DRY_RUN = process.env.DRY_RUN !== 'false';
+
+if (!MONGODB_URI) {
+  console.error('MONGODB_URI not set. Either set it in .env.local or pass TARGET_MONGODB_URI env var.');
+  process.exit(1);
+}
+
+// Extract DB name from the URI path (e.g. .../abl_dev or .../abl_prod)
+const DB_NAME = new URL(MONGODB_URI.replace('mongodb+srv://', 'https://')).pathname.replace('/', '') || 'abl_dev';
+
+/**
+ * Mirrors the server-side deriveAblDate: ABL day rolls over at 08:00 UTC.
+ * A save at 01:30 UTC on May 27 belongs to the May 26 ABL day.
+ */
+function deriveAblDate(date) {
+  const d = new Date(date);
+  if (d.getUTCHours() < 8) {
+    d.setUTCDate(d.getUTCDate() - 1);
+  }
+  return d.toISOString().slice(0, 10);
+}
+
+async function main() {
+  const client = new MongoClient(MONGODB_URI);
+  try {
+    await client.connect();
+    const db = client.db(DB_NAME);
+
+    console.log(`[fix-effectivedate-bug] DRY_RUN=${DRY_RUN}  db=${DB_NAME}\n`);
+
+    // ── Step 1: Find all lineups where effectiveDate > deriveAblDate(updatedAt) ──
+    // Uses a MongoDB aggregation to compute the expected effective date server-side.
+    // $hour in UTC: if >= 8 → same UTC date; if < 8 → subtract one day.
+    const candidates = await db.collection('lineups').aggregate([
+      {
+        $match: {
+          updatedAt: { $exists: true, $type: 'date' },
+          effectiveDate: { $exists: true },
+        },
+      },
+      {
+        $addFields: {
+          expectedEffectiveDate: {
+            $dateToString: {
+              format: '%Y-%m-%d',
+              timezone: 'UTC',
+              date: {
+                $cond: {
+                  if: { $gte: [{ $hour: { date: '$updatedAt', timezone: 'UTC' } }, 8] },
+                  then: '$updatedAt',
+                  else: { $subtract: ['$updatedAt', 86_400_000] }, // -1 day in ms
+                },
+              },
+            },
+          },
+        },
+      },
+      {
+        // Only keep docs where the stored effectiveDate is ahead of where it should be
+        $match: {
+          $expr: { $gt: ['$effectiveDate', '$expectedEffectiveDate'] },
+        },
+      },
+      { $sort: { updatedAt: -1 } },
+    ]).toArray();
+
+    if (candidates.length === 0) {
+      console.log('No candidate lineups found. Nothing to fix.');
+      return;
+    }
+
+    console.log(`Found ${candidates.length} candidate lineup(s) with mismatched effectiveDate.\n`);
+
+    // ── Step 2: Confirm each was truly pre-lock (updatedAt < first MLB pitch) ──
+    const affected = [];
+
+    for (const lineup of candidates) {
+      const expectedDate = lineup.expectedEffectiveDate;
+
+      // Look up the first MLB game start for that date
+      const firstGame = await db.collection('mlbgameschemas').findOne(
+        {
+          officialDate: expectedDate,
+          gameType: 'R',
+          'status.startTimeTBD': { $ne: true },
+        },
+        { sort: { gameDate: 1 } },
+      );
+
+      // Fall back to 18:00 UTC (noon CT) if no schedule entry found
+      const lockTime = firstGame ? new Date(firstGame.gameDate) : new Date(`${expectedDate}T18:00:00Z`);
+
+      if (lineup.updatedAt < lockTime) {
+        affected.push({
+          doc: lineup,
+          expectedDate,
+          lockTime: lockTime.toISOString(),
+        });
+      } else {
+        console.log(
+          `  SKIP (post-lock save): _id=${lineup._id}  team=${lineup.ablTeam}` +
+          `  savedAt=${lineup.updatedAt.toISOString()}  lockTime=${lockTime.toISOString()}`,
+        );
+      }
+    }
+
+    if (affected.length === 0) {
+      console.log('\nAll candidates were post-lock saves — no bug-related fixes needed.');
+      return;
+    }
+
+    console.log(`\n${affected.length} lineup(s) affected by the bug:\n`);
+
+    // ── Step 3: Report (and optionally fix) each affected lineup ──
+    for (const { doc, expectedDate, lockTime } of affected) {
+      const teamStr = doc.ablTeam?.toString();
+      console.log(
+        `  _id=${doc._id}  team=${teamStr}\n` +
+        `    savedAt          : ${doc.updatedAt.toISOString()}\n` +
+        `    lockTime         : ${lockTime}\n` +
+        `    storedEffDate    : ${doc.effectiveDate}  (WRONG)\n` +
+        `    correctEffDate   : ${expectedDate}\n`,
+      );
+
+      if (DRY_RUN) continue;
+
+      // Check whether a document with the correct effectiveDate already exists
+      const existingCorrect = await db.collection('lineups').findOne({
+        ablTeam: doc.ablTeam,
+        effectiveDate: expectedDate,
+      });
+
+      if (existingCorrect) {
+        // A lineup for the correct date already exists.
+        // The bugged save is more recent, so overwrite the existing doc's roster,
+        // then delete the bugged doc.
+        await db.collection('lineups').updateOne(
+          { _id: existingCorrect._id },
+          {
+            $set: {
+              roster: doc.roster,
+              updatedAt: doc.updatedAt, // preserve original save time
+            },
+          },
+        );
+        await db.collection('lineups').deleteOne({ _id: doc._id });
+        console.log(
+          `    FIXED (merged): updated existing doc ${existingCorrect._id}` +
+          ` with roster from bugged doc, deleted bugged doc ${doc._id}`,
+        );
+      } else {
+        // No conflict — simply correct the effectiveDate
+        await db.collection('lineups').updateOne(
+          { _id: doc._id },
+          { $set: { effectiveDate: expectedDate } },
+        );
+        console.log(`    FIXED: effectiveDate ${doc.effectiveDate} → ${expectedDate}`);
+      }
+    }
+
+    if (!DRY_RUN) {
+      console.log('\nFixes applied. Re-run game recalculation for the affected dates to update scores.');
+    } else {
+      console.log('\n[DRY RUN] No changes written. Set DRY_RUN=false to apply.');
+    }
+  } finally {
+    await client.close();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/recalculate-affected-dates.mjs
+++ b/scripts/recalculate-affected-dates.mjs
@@ -1,0 +1,92 @@
+/**
+ * scripts/recalculate-affected-dates.mjs
+ *
+ * Triggers game-score recalculation for all dates affected by the
+ * effectiveDate bug (April 16 – May 26, 2026) via the local Next.js app.
+ *
+ * Prerequisites:
+ *   1. Run: DRY_RUN=false node scripts/fix-effectivedate-bug.mjs
+ *   2. Start the local server: pnpm dev
+ *   3. .env.local must contain CRON_SECRET=abl-dev-cron (already added)
+ *      — restart the dev server after adding it
+ *
+ * Usage:
+ *   node scripts/recalculate-affected-dates.mjs
+ *   APP_URL=http://localhost:3001 node scripts/recalculate-affected-dates.mjs
+ */
+
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// --- Parse .env.local ---
+const envPath = resolve(__dirname, '..', '.env.local');
+const env = Object.fromEntries(
+  readFileSync(envPath, 'utf8').split('\n')
+    .filter(l => l.includes('=') && !l.startsWith('#'))
+    .map(l => {
+      const idx = l.indexOf('=');
+      return [l.slice(0, idx).trim(), l.slice(idx + 1).trim()];
+    })
+);
+
+const CRON_SECRET = process.env.CRON_SECRET || env.CRON_SECRET;
+if (!CRON_SECRET) {
+  console.error('CRON_SECRET not found in .env.local. Add CRON_SECRET=abl-dev-cron and restart pnpm dev.');
+  process.exit(1);
+}
+
+// The full range covering all 58 affected lineups found in the dry run.
+// Dates outside this range had no bug-affected games.
+const DATE_START = '2026-04-16';
+const DATE_END = '2026-05-26';
+
+const APP_URL = process.env.APP_URL || 'http://localhost:3000';
+// Uses /api/games/recalculate — only re-locks rosters + recalculates scores.
+// Does NOT re-fetch MLB stats from the external API.
+const ENDPOINT = `${APP_URL}/api/games/recalculate`;
+
+console.log(`ABL effectiveDate fix — recalculating game scores (no MLB stat refresh)`);
+console.log(`  Endpoint   : ${ENDPOINT}`);
+console.log(`  Date range : ${DATE_START} → ${DATE_END}`);
+console.log(`  (Processes all ABL games in range; may take 1–3 minutes)\n`);
+
+let resp;
+try {
+  resp = await fetch(ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${CRON_SECRET}`,
+    },
+    body: JSON.stringify({
+      dateStart: `${DATE_START}T00:00:00.000Z`,
+      dateEnd:   `${DATE_END}T23:59:59.999Z`,
+      save: true,
+      isFinal: true,
+    }),
+  });
+} catch (err) {
+  console.error(`\nFailed to reach ${ENDPOINT}. Is pnpm dev running?\n`, err.message);
+  process.exit(1);
+}
+
+if (!resp.ok) {
+  const text = await resp.text();
+  console.error(`\nAPI returned ${resp.status}:\n${text}`);
+  process.exit(1);
+}
+
+const data = await resp.json();
+
+console.log('Recalculation complete.\n');
+console.log(JSON.stringify(data, null, 2));
+
+console.log(`\nSummary:`);
+console.log(`  Games recalculated : ${data.processed ?? '?'}`);
+console.log(`  Skipped            : ${data.skipped   ?? '?'}`);
+console.log(`  Errors             : ${data.errors    ?? '?'}`);
+console.log(`\nNext step: node scripts/audit-score-changes.mjs`);
+console.log(`  (Requires PROD_MONGODB_URI in environment or .env.local)`);


### PR DESCRIPTION
ABL games store gameDate as midnight UTC. By evening UTC, querying gameDate >= now skipped today and returned tomorrow, causing pre-lock roster saves to get effectiveDate = D+1. Scoring uses effectiveDate <= officialDate so the lineup was invisible to scoring.

Fix: use deriveAblDate(new Date()) for today's ABL date string, then only query for next game strictly after tomorrow when post-lock.

Also adds CRON_SECRET Bearer token auth to /api/games/recalculate so the recalculation script can call it without an admin session.

Scripts included for one-time historical DB fix and audit:
- scripts/fix-effectivedate-bug.mjs
- scripts/recalculate-affected-dates.mjs
- scripts/audit-score-changes.mjs

Affected: 58 lineups across 2026-04-16 to 2026-05-26
Outcome changes: 1 (Handbaskets vs Rats on 2026-05-26)