### PR TITLE
Make roster table header sticky to viewport, allow full-page scroll

### DIFF
--- a/app/[league]/[season]/teams/[id]/roster/page.tsx
+++ b/app/[league]/[season]/teams/[id]/roster/page.tsx
@@ -829,12 +829,15 @@ export default function TeamRosterPage({ embedded = false }: { embedded?: boolea
         )}
       </div>
 
-      <div className="bg-white rounded-lg shadow-lg overflow-x-auto overflow-y-auto max-h-[calc(100dvh-320px)] min-h-60">
+      <div className="bg-white rounded-lg shadow-lg min-h-60">
         {rosterView === 'eligibility' && posLogsLoading && (
           <div className="text-center py-4 text-sm text-gray-500">Loading position data…</div>
         )}
         <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50 sticky top-0 z-10 shadow-sm">
+          <thead
+            className="bg-gray-50 sticky z-10 shadow-sm"
+            style={{ top: 'var(--app-header-height, 0px)' }}
+          >
             <tr>
               <th className="px-2 py-3 w-8"></th>
               <th className="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase w-12">#</th>

--- a/app/ui/header.tsx
+++ b/app/ui/header.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 import { toggleNav } from '@/app/ui/navigation';
 
@@ -25,6 +25,21 @@ export default function Header() {
   const pathname = usePathname();
   const [user, setUser] = useState<User | null>(null);
   const [myLeagues, setMyLeagues] = useState<MyLeagueEntry[]>([]);
+  const headerRef = useRef<HTMLElement>(null);
+
+  // Expose the rendered header height as a CSS variable so other sticky
+  // elements (e.g. the roster table header) can stick just below it.
+  useEffect(() => {
+    const el = headerRef.current;
+    if (!el) return;
+    const setHeightVar = () => {
+      document.documentElement.style.setProperty('--app-header-height', `${el.offsetHeight}px`);
+    };
+    setHeightVar();
+    const observer = new ResizeObserver(setHeightVar);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
 
   const pathMatch = pathname?.match(/^\/([^/]+)(?:\/(\d{4})(\/.*)?)?$/);
   const pathLeague = pathMatch?.[1]?.toLowerCase();
@@ -84,7 +99,7 @@ export default function Header() {
   }, []);
 
   return (
-    <header className="bg-blue-600 text-white px-4 py-3 shadow-md sticky top-0 z-20">
+    <header ref={headerRef} className="bg-blue-600 text-white px-4 py-3 shadow-md sticky top-0 z-20">
       <div className="flex justify-between items-center">
         <div className="flex items-center gap-3">
           <button


### PR DESCRIPTION
Lets the page scroll as a whole instead of nesting a separate scroll container inside the roster table, while keeping the column header pinned just below the nav bar. This lets drag-and-drop reordering span the full roster without hitting the old scroll boundary.